### PR TITLE
Enable wc tool to generate details when text file is provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+test.txt
+ccwc

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,12 @@
 all: build_target clean
 
 build_target:
-	@echo "Compiling the java main file"
-	javac -d build src/main/java/org/example/Main.java
-	@echo "Doing the build"
-	jar --create --file ccwc.jar --main-class org.example.Main -C build .
-	@echo "Generating the executable jar"
-	jar tf ccwc.jar
+	@echo "Generating the jar"
+	./gradlew jar
+	jar tf build/libs/ccwc.jar
 	@echo "Generating the native image of the jar file"
-	native-image -jar ccwc.jar
+	native-image -jar build/libs/ccwc.jar
 
 clean:
 	@echo "Cleaning up the generated jar"
-	rm *.jar
+	rm build/libs/*.jar

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -1,9 +1,10 @@
 package org.example;
 
+import org.example.invokers.CommandLineInvoker;
+
 public class Main {
     public static void main(String[] args) {
-        for (String arg : args) {
-            System.out.println(arg);
-        }
+        // invoking the command line
+        CommandLineInvoker.getInstance(args).invoke();
     }
 }

--- a/src/main/java/org/example/constants/ActionArgumentConstants.java
+++ b/src/main/java/org/example/constants/ActionArgumentConstants.java
@@ -1,8 +1,9 @@
 package org.example.constants;
 
 public class ActionArgumentConstants {
-    public static final String LINES = "l";
-    public static final String WORDS = "w";
-    public static final String BYTES = "b";
-    public static final String ALL = "all";
+    public static final String LINES = "-l";
+    public static final String WORDS = "-w";
+    public static final String BYTES = "-c";
+    public static final String CHARS = "-m";
+    public static final String ALL = "-all";
 }

--- a/src/main/java/org/example/invokers/CommandLineInvoker.java
+++ b/src/main/java/org/example/invokers/CommandLineInvoker.java
@@ -1,4 +1,4 @@
-package org.example;
+package org.example.invokers;
 
 import org.example.constants.ActionArgumentConstants;
 import org.example.processors.FileProcessor;
@@ -6,8 +6,9 @@ import org.example.processors.FileProcessor;
 
 public class CommandLineInvoker {
     private final String[] args;
+    private static CommandLineInvoker instance = null;
 
-    public CommandLineInvoker(String[] args) {
+    private CommandLineInvoker(String[] args) {
         this.args = args;
     }
 
@@ -26,39 +27,42 @@ public class CommandLineInvoker {
         System.out.println(wordCount + "\t" + fileProcessor.getFilePath());
     }
 
+    private void invokeCharacterCountForFile(FileProcessor fileProcessor) {
+        long charCount = fileProcessor.getChars();
+        System.out.println(charCount + "\t" + fileProcessor.getFilePath());
+    }
+
     private void invokeAllCountsForFile(FileProcessor fileProcessor) {
         long lineCount = fileProcessor.getLines();
         long byteCount = fileProcessor.getBytes();
         long wordCount = fileProcessor.getWords();
 
-        System.out.println(lineCount + "\t" + byteCount + "\t" + wordCount + "\t" + fileProcessor.getFilePath());
+        System.out.println(lineCount + "\t" + wordCount + "\t" + byteCount + "\t" + fileProcessor.getFilePath());
     }
 
     private void invokeForFile(String textFileName, String actionArgument) {
         // invoke a file processor
         FileProcessor fileProcessor = FileProcessor.generateFileProcessor(textFileName);
         if (fileProcessor.isReadSuccess()) {
-            if (actionArgument.startsWith("-")) {
-                String action = actionArgument.substring(1);
-                switch (action) {
-                    case ActionArgumentConstants.LINES:
-                        invokeLineCountForFile(fileProcessor);
-                        break;
-                    case ActionArgumentConstants.BYTES:
-                        invokeByteCountForFile(fileProcessor);
-                        break;
-                    case ActionArgumentConstants.WORDS:
-                        invokeWordCountForFile(fileProcessor);
-                        break;
-                    case ActionArgumentConstants.ALL:
-
-                    default:
-                        System.out.println("Unknown action type: " + actionArgument);
-                        System.exit(1);
-                }
-            } else {
-                System.out.println("Permissible Action types are [-w, -b, -l]");
-                System.exit(1);
+            switch (actionArgument) {
+                case ActionArgumentConstants.LINES:
+                    invokeLineCountForFile(fileProcessor);      // works correctly
+                    break;
+                case ActionArgumentConstants.BYTES:
+                    invokeByteCountForFile(fileProcessor);
+                    break;
+                case ActionArgumentConstants.WORDS:
+                    invokeWordCountForFile(fileProcessor);
+                    break;
+                case ActionArgumentConstants.CHARS:
+                    invokeCharacterCountForFile(fileProcessor);
+                    break;
+                case ActionArgumentConstants.ALL:
+                    invokeAllCountsForFile(fileProcessor);
+                    break;
+                default:
+                    System.out.println("Unknown action type: " + actionArgument);
+                    System.exit(1);
             }
         } else {
             System.out.println("Invalid file.");
@@ -68,7 +72,6 @@ public class CommandLineInvoker {
 
     public void invoke() {
         if (args.length == 2) {
-            // this means that there are two attributes
             String actionArgument = args[0];
             String textFileName = args[1];
             invokeForFile(textFileName, actionArgument);
@@ -78,5 +81,12 @@ public class CommandLineInvoker {
         } else {
             System.out.println("TO BE IMPLEMENTED...");
         }
+    }
+
+    public static CommandLineInvoker getInstance(String[] args) {
+        if (instance == null) {
+            instance = new CommandLineInvoker(args);
+        }
+        return instance;
     }
 }

--- a/src/main/java/org/example/metadata/FileMetadata.java
+++ b/src/main/java/org/example/metadata/FileMetadata.java
@@ -1,0 +1,6 @@
+package org.example.metadata;
+
+import java.nio.charset.Charset;
+
+public record FileMetadata(String fileContents, long totalBytes, Charset encoding) {
+}

--- a/src/main/java/org/example/processors/Processor.java
+++ b/src/main/java/org/example/processors/Processor.java
@@ -6,4 +6,6 @@ public abstract class Processor {
     public abstract long getLines();
 
     public abstract long getWords();
+
+    public abstract long getChars();
 }


### PR DESCRIPTION
The following features have been provided for the **ccwc** tool as of now when the location of the text file is provided as a command line argument to the tool.

1. support for word count flag using **-w**
2. support for line count flag using **-l**
3. support for byte count flag using **-c**
4. support for character count flag using **-m**
5. Support is provided for the default display of details when neither flag is provided.